### PR TITLE
Fix delete files

### DIFF
--- a/lib/delete-duplicates.js
+++ b/lib/delete-duplicates.js
@@ -3,12 +3,15 @@ const fsDef = require('fs');
 module.exports = ({
     fs = fsDef,
 } = {}) => async ({ duplicates }) => {
-    const deleteOperations = duplicates.map(duplicate => new Promise((resolve, reject) => {
-        fs.unlink(duplicate, (err) => {
-            if (err) reject(err);
-            resolve();
-        });
-    }));
+    const flattenArray = array => array.reduce((acc, nest) => [...acc, ...nest], []);
+
+    const deleteOperations = flattenArray(Object.values(duplicates))
+        .map(duplicate => new Promise((resolve, reject) => {
+            fs.unlink(duplicate, (err) => {
+                if (err) reject(err);
+                resolve();
+            });
+        }));
 
     await Promise.all(deleteOperations);
 };

--- a/tests/delete-duplicates.test.js
+++ b/tests/delete-duplicates.test.js
@@ -10,11 +10,13 @@ describe('Delete Duplicates', () => {
         };
 
         const fakeDuplicates = {
-            duplicates: [
-                getDummyFiles[0],
-                getDummyFiles[1],
-                getDummyFiles[2],
-            ],
+            duplicates: {
+                randomMd5: [
+                    getDummyFiles[0],
+                    getDummyFiles[1],
+                    getDummyFiles[2],
+                ],
+            },
         };
 
         const deleteDuplicates = deleteDuplicatesFactory(fakeDependencies);


### PR DESCRIPTION
The delete duplicates function took an array of strings as an input from the previous version. Definitely indicates my tests suck.

### Fix
 - Input type changed from array to object